### PR TITLE
gitignore記載

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@
 
 # Ignore Byebug command history file.
 .byebug_history
+config/secrets.yml


### PR DESCRIPTION
#What
Railsアプリケーションの中にある。.gitignoreファイルにconfig/secrets.ymlと記載。

#Why
secrets.ymlというファイルには、我々のアプリケーションに関するパスワードが多く記載されているファイルです。ただ、現状だとsecrets.ymlはGitHub上に公開されており、誰でもパスワードの値が見れる形となっている。この.gitignoreにconfig/secrets.ymlすることでsecrets.ymlをGitHubの監視下から外すことができ、GitHub上に公開されずに済む。