### PR TITLE
DB 重複users削除

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,8 +2,8 @@ Rails.application.routes.draw do
   devise_for :users, controllers: {
     registrations: 'users/registrations',
 }
-
-  resources :signup do
+  
+resources :signup do
     collection do
       get 'index'
       get 'mem'
@@ -13,7 +13,6 @@ Rails.application.routes.draw do
   end
 
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
-
   root to: 'items#index'
   resources :items
 end


### PR DESCRIPTION
# waht
userテーブルの重複を解消しました。
# why
rails db:migrateできないため。