### PR TITLE
ユーザー毎の購入、編集ページ制限

### DIFF
--- a/app/assets/stylesheets/_edit.scss
+++ b/app/assets/stylesheets/_edit.scss
@@ -64,7 +64,7 @@
                 .main-item-imag{
                   td{
                     img{
-                      object-fit: cover;
+                      object-fit: contain;
                       height: 346px;
                     }
                   }
@@ -75,7 +75,7 @@
                   td{
                     margin: 7px;
                     img{
-                      object-fit: cover; 
+                      object-fit: contain; 
                     }
                   }
                 }
@@ -137,36 +137,39 @@
           }
         }
         .optionalArea {
-          display: flex;
-          justify-content: space-between;
-          ul {
-            margin: 10px 0 0;
-            display: flex;
-            .likeBtn {
+          
+          ul{
+            
+            li.likeBtn {
               margin-right: auto;
               padding: 6px 10px;
               border-radius: 40px;
               color: #3CCACE;
               border: 1px solid #ffb340;
-              list-style: none;
+              display: inline-block;
             }
-          }
-          ul {
-            margin: 10px 0 0;
-            display: flex;
-            list-style: none;
-            .optionalBtn {
-              font-size: 14px;
-              a {
-                padding: 6px 10px;
-                display: inline-block;
-                border-radius: 4px;
-                color: #333;
-                border: 1px solid #333;
-                text-decoration: none;
-              }
-            } 
-          }
+            li.optionalBtn {
+              display: inline-block;
+              padding: 6px 10px;
+              border-radius: 4px;
+              color: #a9a9a9;
+              border: 1px solid #a9a9a9;
+              text-decoration: none;
+            
+            }
+          }  
+        }
+        
+        .item-edit-btn{
+          font-size: 24px;
+          line-height: 60px;
+          display: block;
+          margin: 65px;
+          background: #3cb371;
+          color: #fff;
+          text-align: center;
+          font-weight: 600;
+          border-radius: 7px;
         }
         .item-buy-btn{
           font-size: 24px;
@@ -174,17 +177,6 @@
           display: block;
           margin: 65px;
           background: #FF6666;
-          color: #fff;
-          text-align: center;
-          font-weight: 600;
-          border-radius: 7px;
-        }
-        .item-edit-btn{
-          font-size: 24px;
-          line-height: 60px;
-          display: block;
-          margin: 65px;
-          background: #3cb371;
           color: #fff;
           text-align: center;
           font-weight: 600;

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,4 +1,7 @@
 class ItemsController < ApplicationController
+
+  before_action :ensure_correct_user,{only: [:edit,:buy,]} 
+
   def index
     @image = Image.all
     @item = Item.all
@@ -8,22 +11,22 @@ class ItemsController < ApplicationController
   end
 
   def show
-    gon.image = Image.find(1)
-    @image = Image.find(1)
-    @item = Item.find(1)
+    gon.image = Image.find_by(id:1)
+    @image = Image.find_by(id:1)
+    @item = Item.find_by(id:1)
+    @user = User.find_by(id:1)
   end
 
+  # 出品者以外がURLから直接的に編集、購入画面に進めないようにするため
+  def ensure_correct_user
+      @item = Item.find_by(id:1)
+    if @item.user_id != current_user.id
+      flash[:notice] = "権限がありません"
+      redirect_to("/items/show")
+    end
+  end
 
   def edit
   end 
 
 end
-
-
-
-# def ensure_correct_user
-#   @post = Post.find_by(id:params[:id])
-#   if @user.user_id != @current_user.id
-#     flash[:notice] = "権限がありません"
-#     redirect_to("/items/edit")
-# end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -22,7 +22,7 @@ class ItemsController < ApplicationController
       @item = Item.find(1)
     if @item.user_id != current_user.id
       flash[:notice] = "権限がありません"
-      redirect_to("item_path")
+      redirect_to(item_path(@item))
     end
   end
 

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -11,18 +11,18 @@ class ItemsController < ApplicationController
   end
 
   def show
-    gon.image = Image.find_by(id:1)
-    @image = Image.find_by(id:1)
-    @item = Item.find_by(id:1)
-    @user = User.find_by(id:1)
+    gon.image = Image.find(1)
+    @image = Image.find(1)
+    @item = Item.find(1)
+    @user = User.find(1)
   end
 
   # 出品者以外がURLから直接的に編集、購入画面に進めないようにするため
   def ensure_correct_user
-      @item = Item.find_by(id:1)
+      @item = Item.find(1)
     if @item.user_id != current_user.id
       flash[:notice] = "権限がありません"
-      redirect_to("/items/show")
+      redirect_to("item_path")
     end
   end
 

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -59,7 +59,7 @@
                 %tbody
                   %tr
                     %th 出品者
-                    %td= link_to(@user.nickname,"items/#{@user.id}")
+                    %td= link_to @user.nickname,item_path(@user)
                   %tr
                     %th カテゴリー
                     %td
@@ -94,10 +94,10 @@
                   %i.fa.fa-flag 不適切な商品の通報
                   -# itemの外部キーとcurrent_user.idが同じであれば出品者なので編集ボタンが表示される。参考カリキュラムhttps://master.tech-camp.in/curriculums/178
                 - if user_signed_in? && current_user.id == @item.user_id 
-                  = link_to("編集","items/#{@item.id}/edit",class:"item-edit-btn")
+                  = link_to("編集",edit_path(@item.id),class:"item-edit-btn")
                   -# 非出品者には購入ボタンが表示される。
                 - else
-                  = link_to("購入","items/#{@item.id}/buy",class:"item-buy-btn")
+                  = link_to("購入",item_path(@item.id),class:"item-buy-btn")
             %form.item-Description
               %textarea= @item.description
           .commentBox

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -20,6 +20,10 @@
       %i.fa.fa-angle-right
     %li
       %p product2
+
+- if flash[:notice]
+  %p= flash[:notice]
+
 .main
   .showmain
     .contentLeftqq
@@ -55,7 +59,7 @@
                 %tbody
                   %tr
                     %th 出品者
-                    %td
+                    %td= link_to(@user.nickname,"items/#{@user.id}")
                   %tr
                     %th カテゴリー
                     %td
@@ -84,16 +88,16 @@
                     %td= @item.shopping_date
             .optionalArea
               %ul
-                %li#likeBtn.optionalBtn.likeBtn
-                  %i.fa.fa-star
-                  お気に入り 0
-              %ul.optional
+                %li.likeBtn
+                  %i.fa.fa-star お気に入り 0
                 %li.optionalBtn
-                  %a{href:"#"}
-                    %i.fa.fa-flag
-                    不適切な商品の通報
-            %a.item-buy-btn{href:item_path}購入画面に進む
-            %a.item-edit-btn{href:item_path}商品編集
+                  %i.fa.fa-flag 不適切な商品の通報
+                  -# itemの外部キーとcurrent_user.idが同じであれば出品者なので編集ボタンが表示される。参考カリキュラムhttps://master.tech-camp.in/curriculums/178
+                - if user_signed_in? && current_user.id == @item.user_id 
+                  = link_to("編集","items/#{@item.id}/edit",class:"item-edit-btn")
+                  -# 非出品者には購入ボタンが表示される。
+                - else
+                  = link_to("購入","items/#{@item.id}/buy",class:"item-buy-btn")
             %form.item-Description
               %textarea= @item.description
           .commentBox


### PR DESCRIPTION
# What
## 出品者側の処理
- 商品詳細画面から購入画面に遷移できない。URLから直接遷移するとメッセージとリダイレクトされる。
- 商品詳細画面から商品情報の編集に遷移できるようになっている。
- 商品詳細画面に購入ボタンが表示されない。
## 非出品者側の処理
- 商品詳細画面に編集に遷移できないようになっている。URLから直接遷移するとメッセージとリダイレクトされる。
- 商品詳細画面から商品情報の購入に遷移できるようになっている。
- 商品詳細画面に編集ボタンが表示されない。
# Why
- 商品を誰でも編集,購入できる状態だったため